### PR TITLE
Raise bounds on `megaparsec`

### DIFF
--- a/tiktoken.cabal
+++ b/tiktoken.cabal
@@ -27,7 +27,7 @@ library
                     , containers           >= 0.5.0.0
                     , deepseq              >= 1.4.0.0
                     , filepath
-                    , megaparsec                          < 9.7
+                    , megaparsec                          < 9.8
                     , pcre-light           >= 0.2
                     , raw-strings-qq     
                     , text


### PR DESCRIPTION
`tiktoken` 1.0.3 is currently broken on nixpkgs-unstable due to `megaparsec` less than 9.7 not being found. I built `tiktoken` with `doJailBreak` applied and it built with all tests passing just fine. This PR raises the upper bound on megaparsec from 9.7 -> 9.8. 